### PR TITLE
Fix SwiftLint workflow push permissions

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -32,6 +32,7 @@ jobs:
         swiftlint autocorrect
         
     - name: Commit SwiftLint fixes
+      if: github.event_name == 'push'
       run: |
         git config --local user.email "action@github.com"
         git config --local user.name "GitHub Action"
@@ -39,7 +40,8 @@ jobs:
         git diff-index --quiet HEAD || git commit -m "Apply SwiftLint fixes"
         
     - name: Push SwiftLint fixes
+      if: github.event_name == 'push'
       uses: ad-m/github-push-action@master
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        branch: ${{ github.ref }}
+        branch: ${{ github.ref_name }}


### PR DESCRIPTION
Prevent `code-quality` workflow from failing on pull requests by only pushing SwiftLint fixes on `push` events.

The workflow previously attempted to commit and push SwiftLint fixes directly to pull request branches, which often lack write permissions, especially for forks or protected branches. This change ensures automatic fixes are applied only when code is pushed directly to main branches, where the workflow has necessary permissions.