### PR TITLE
Fix missing exportOptions.plist in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
         xcodebuild -exportArchive \
           -archivePath ./build/WhiteNoise.xcarchive \
           -exportPath ./build/ipa \
-          -exportOptionsPlist exportOptions.plist
+          -exportOptionsPlist exportOptions-dev.plist
           
     - name: Upload iOS build artifacts
       uses: actions/upload-artifact@v3

--- a/exportOptions-dev.plist
+++ b/exportOptions-dev.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>method</key>
+	<string>development</string>
+	<key>signingStyle</key>
+	<string>manual</string>
+	<key>stripSwiftSymbols</key>
+	<true/>
+	<key>uploadBitcode</key>
+	<false/>
+	<key>uploadSymbols</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
Create `exportOptions-dev.plist` and update `release.yml` to use it, fixing IPA export failure due to code signing conflict.

The `release.yml` workflow's `xcodebuild -exportArchive` step failed because the existing `exportOptions.plist` required App Store distribution with automatic code signing, while the preceding build steps explicitly skipped code signing. This PR introduces `exportOptions-dev.plist` configured for development builds with manual signing, allowing IPA creation from unsigned archives.